### PR TITLE
WebStormでのデバッグを楽にする

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -77,5 +77,10 @@ export default {
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
+    extend(config, ctx) {
+      // IDEでデバッグを行う設定
+      // WebStormでは動作確認済ですが、VSCodeでは未確認です
+      config.devtool = ctx.isClient ? 'eval-source-map' : 'inline-source-map'
+    }
   }
 }


### PR DESCRIPTION
## 概要
- 毎度毎度Console.logでデバッグをするのは手間かつ消し忘れなどもありそうなので、IDEでブレークポイントを置くだけで手軽にデバッグできるようにする
- 基本的には本PRの内容を取り込めば、IDE上で所定の位置にブレークポイントを置くだけでデバッグできるはず。
- Nuxt.jsのデバッグ環境を構築する上で、 サーバサイドで動作するNode.jsのデバッグと ブラウザ上で動作するSPAの場合のデバッグ
の2つを考慮する必要があるため、その設定も反映する

## 動画
- https://drive.google.com/file/d/1pkLx7Wm_DPWXWQu0-XjbTERRIoBW38dY/view?usp=sharing

## 参考
- https://medium.com/@fernyettheplant/nuxt-js-debugging-for-webstorm-9b4ef5415a5